### PR TITLE
Added the support for all unicode chars.

### DIFF
--- a/droidicon/src/main/java/com/thedazzler/droidicon/Droidicon.java
+++ b/droidicon/src/main/java/com/thedazzler/droidicon/Droidicon.java
@@ -1690,12 +1690,6 @@ public class Droidicon
 
     }
 
-    public static Map<String, Integer> getIconMap()
-    {
-        return iconMap;
-    }
-
-
     public static TypefaceManager.IconicTypeface getIconicTypeface(String icon)
     {
         if(icon.startsWith("fa"))
@@ -1710,10 +1704,17 @@ public class Droidicon
             return TypefaceManager.IconicTypeface.GOOGLE_MATERIAL_DESIGN;
         else if(icon.startsWith("meteo"))
             return TypefaceManager.IconicTypeface.METEOCON;
+        else if(icon.startsWith("unicode"))
+            return TypefaceManager.IconicTypeface.UNICODE;
         else return null;
     }
 
     public static int getIconUtfValue(String icon) {
+        if (icon.startsWith("unicode")) {
+            //The icon name should be like unicode-0x7727
+            String unicodeStr = icon.substring(icon.indexOf("-") + 1);
+            return Integer.decode(unicodeStr);
+        }
         return iconMap.get(icon);
     }
 }

--- a/droidicon/src/main/java/com/thedazzler/droidicon/IconicFontDrawable.java
+++ b/droidicon/src/main/java/com/thedazzler/droidicon/IconicFontDrawable.java
@@ -216,7 +216,7 @@ public class IconicFontDrawable extends Drawable {
 
     private void updateIcon(String icon) {
         mIcon = icon;
-        mIconUtfChars = Character.toChars(Droidicon.getIconMap().get(icon));
+        mIconUtfChars = Character.toChars(Droidicon.getIconUtfValue(icon));
         mIconPaint.setTypeface(Droidicon.getIconicTypeface(icon).getTypeface(mContext));
     }
 

--- a/droidicon/src/main/java/com/thedazzler/droidicon/util/TypefaceManager.java
+++ b/droidicon/src/main/java/com/thedazzler/droidicon/util/TypefaceManager.java
@@ -31,12 +31,13 @@ public class TypefaceManager {
         FONT_AWESOME(R.raw.fontawesome_webfont),
         ICONIC(R.raw.iconic),
         GOOGLE_MATERIAL_DESIGN(R.raw.google_material_design),
-        METEOCON(R.raw.meteocons);
+        METEOCON(R.raw.meteocons),
+        UNICODE(null);
 
-        private final int mTypefaceResourceId;
+        private final Integer mTypefaceResourceId;
         private Typeface mTypeface;
 
-        private IconicTypeface(int typefaceResourceId) {
+        private IconicTypeface(Integer typefaceResourceId) {
             mTypefaceResourceId = typefaceResourceId;
         }
 
@@ -48,6 +49,9 @@ public class TypefaceManager {
          * @return {@link Typeface}
          */
         public Typeface getTypeface(final Context context) {
+            if (mTypefaceResourceId == null) {
+                return Typeface.DEFAULT;
+            }
             if (mTypeface == null) {
                 mTypeface = createTypefaceFromResource(context, mTypefaceResourceId);
             }


### PR DESCRIPTION
So that every unicode character can be parsed to IconicFontDrawable by simply passing string like 'unicode-0x2640' as the icon name!
